### PR TITLE
Expand functions

### DIFF
--- a/pytasa/io.py
+++ b/pytasa/io.py
@@ -161,4 +161,76 @@ def load_mast_simple(fh, eunit="GPa", dunit="Kgm3", dnorm=False):
     rho = convert_to_kgm3(rho, dunit) 
 
     return c_out, rho
+
+
+def expand_cubic(c11,c44,c12):
+    """docstring for expand_cubic"""
+    
+    C = np.array([[ c11, c12, c12, 0.0, 0.0, 0.0], 
+                  [ c12, c11, c12, 0.0, 0.0, 0.0], 
+                  [ c12, c12, c11, 0.0, 0.0, 0.0],
+                  [ 0.0, 0.0, 0.0, c44, 0.0, 0.0],
+                  [ 0.0, 0.0, 0.0, 0.0, c44, 0.0],
+                  [ 0.0, 0.0, 0.0, 0.0, 0.0, c44]])
+    
+    return C
+    
+def expand_hexagonal(c11,c33,c44,c12,c13):
+    """docstring for expand_hexagonal"""
+    
+    c66=(c11-c12)/2.
+    
+    C = np.array([[ c11, c12, c13, 0.0, 0.0, 0.0], 
+                  [ c12, c11, c13, 0.0, 0.0, 0.0], 
+                  [ c13, c13, c33, 0.0, 0.0, 0.0],
+                  [ 0.0, 0.0, 0.0, c44, 0.0, 0.0],
+                  [ 0.0, 0.0, 0.0, 0.0, c44, 0.0],
+                  [ 0.0, 0.0, 0.0, 0.0, 0.0, c66]])
+    
+    return C
+
+def expand_trigonal(c11,c33,c44,c12,c13,c14,c15=0.0):
+    """docstring for expand_trigonal"""
+    
+    c66=(c11-c12)/2.
+    
+    C = np.array([[ c11, c12, c13, c14, c15, 0.0], 
+                  [ c12, c11, c13,-c14,-c15, 0.0], 
+                  [ c13, c13, c33, 0.0, 0.0, 0.0],
+                  [ c14,-c14, 0.0, c44, 0.0,-c15],
+                  [ c15,-c15, 0.0, 0.0, c44, c14],
+                  [ 0.0, 0.0, 0.0,-c15, c14, c66]])
+    return C
+
+def expand_orthorhombic(c11,c22,c33,c44,c55,c66,c12,c13,c23):
+    """docstring for expand_orthorhombic"""
+    C = np.array([[ c11, c12, c13, 0.0, 0.0, 0.0], 
+                  [ c12, c22, c23, 0.0, 0.0, 0.0], 
+                  [ c13, c23, c33, 0.0, 0.0, 0.0],
+                  [ 0.0, 0.0, 0.0, c44, 0.0, 0.0],
+                  [ 0.0, 0.0, 0.0, 0.0, c55, 0.0],
+                  [ 0.0, 0.0, 0.0, 0.0, 0.0, c66]])
+    return C
+
+def expand_tetragonal(c11,c33,c44,c66,c12,c13,c16=0.0):
+    """docstring for expand_tetragonal"""
+    C = np.array([[ c11, c12, c13, 0.0, 0.0, c16], 
+                  [ c12, c11, c13, 0.0, 0.0,-c16], 
+                  [ c13, c13, c33, 0.0, 0.0, 0.0],
+                  [ 0.0, 0.0, 0.0, c44, 0.0, 0.0],
+                  [ 0.0, 0.0, 0.0, 0.0, c44, 0.0],
+                  [ c16,-c16, 0.0, 0.0, 0.0, c66]])
+    return C
+
+def expand_monoclinic(c11,c22,c33,c44,c55,c66,c12,c13,c23,c15,c25,c35,c46):
+    """docstring for expand_monoclinic"""
+    C = np.array([[ c11, c12, c13, 0.0, c15, 0.0], 
+                  [ c12, c22, c23, 0.0, c25, 0.0], 
+                  [ c13, c23, c33, 0.0, c35, 0.0],
+                  [ 0.0, 0.0, 0.0, c44, 0.0, c46],
+                  [ c15, c25, c35, 0.0, c55, 0.0],
+                  [ 0.0, 0.0, 0.0, c46, 0.0, c66]])
+    return C
+
+
              

--- a/pytasa/io.py
+++ b/pytasa/io.py
@@ -105,11 +105,11 @@ def load_ematrix(fh, eunit="Mbar"):
 def load_mast_simple(fh, eunit="GPa", dunit="Kgm3", dnorm=False):
     """Load a MSAT 'simple' file
 
-    This file format consists of a serise of lines, each with two integers and a float,
+    This file format consists of a series of lines, each with two integers and a float,
     the integers represent the indicies of the elastic constant (in Voigt notation) and
-    the float is it's value. Major and minor symmetry is assumed and only one of each 
+    the float is its value. Major and minor symmetry is assumed and only one of each 
     pair of off diagonal elements can be provided. Elements outside the range i=(1,6),
-    j=(1,6) are assumed to be the density. Only one desnity can be present. Empty
+    j=(1,6) are assumed to be the density. Only one density can be present. Empty
     lines are ignored and the characters after the comment symbol '%' are removed 
     prior to reading. Any other characters result in an error. 
 
@@ -310,8 +310,8 @@ def build_iso(**kwargs):
     
     M = 2*mu+lam
     E = (mu*((3*lam)+(2*mu)))/(lam+mu)
-    K = lam + (2/3)*mu;
-    nu = lam/(2*(lam+mu));
+    K = lam + (2/3)*mu
+    nu = lam/(2*(lam+mu))
     
 
     C = np.array([[  M, lam, lam, 0.0, 0.0, 0.0],


### PR DESCRIPTION
This pull request addresses #6 .

I've written a number of 'expand' functions to generate full Cij tensors given a list of components of the tensor and a symmetry system. This is a bit different than MS_expand which took a partially filled tensor as an argument, though that functionality could probably be added as a wrapper function.

I've also added the build_iso function, which returns an isotropic tensor and list of elastic constants given any combination of two elastic constants.

Any comments or suggestions?
