### PR TITLE
We want to use an up-to-date pip on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - "nightly"
 # command to install dependencies
 install:
+  - "pip install -U pip setuptools"
   - "pip install -r requirements.txt"
 # command to run tests
 script: nosetests


### PR DESCRIPTION
By the look of things pip 9.0.1 and above should handle
the IPython-5 / IPython-6 choice for python 2.7 / python 3.5.
This adds an "upgrade pip" step to the travis build.